### PR TITLE
Version 1.2.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68
 
 build:
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "exceptiongroup" %}
-{% set version = "1.0.4" %}
+{% set version = "1.2.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/exceptiongroup-{{ version }}.tar.gz
-  sha256: bd14967b79cd9bdb54d97323216f8fdf533e278df937aa2a90089e7d6e06e5ec
+  sha256: 91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68
 
 build:
   script: {{ PYTHON }} -m pip install . -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,8 +41,8 @@ about:
       * Patches to the TracebackException class that properly formats exception groups (installed on import)
       * An exception hook that handles formatting of exception groups through TracebackException (installed on import)
       * Special versions of some of the functions from the traceback module"
-  license: BSD-3-Clause
-  license_family: BSD
+  license: MIT
+  license_family: MIT
   license_file: LICENSE
   dev_url: https://github.com/agronholm/exceptiongroup
   doc_url: https://docs.python.org/3/library/exceptions.html


### PR DESCRIPTION
exceptiongroup 1.2.0

**Destination channel:** defaults

### Links

- [PKG-3906](https://anaconda.atlassian.net/browse/PKG-3906)
- [Upstream repository](https://github.com/agronholm/exceptiongroup/tree/1.2.0)
- Relevant dependency PRs:
  - [PKG-3808](https://anaconda.atlassian.net/browse/PKG-3808)

### Explanation of changes:

- Bump version to `1.2.0`
- Linter fixes
- Add abs.yaml for Python 3.12 build


[PKG-3906]: https://anaconda.atlassian.net/browse/PKG-3906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-3808]: https://anaconda.atlassian.net/browse/PKG-3808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ