### PR TITLE
exceptiongroup 1.3.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,0 @@
-aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,37 +1,42 @@
 {% set name = "exceptiongroup" %}
-{% set version = "1.2.0" %}
+{% set version = "1.3.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/exceptiongroup-{{ version }}.tar.gz
-  sha256: 91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88
 
 build:
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true  # [py<37]
 
 requirements:
   host:
     - python
     - pip
     - flit-scm
-    - wheel
   run:
     - python
+    - typing-extensions >=4.6.0  # [py<313]
 
 test:
+  source_files:
+    - tests
   imports:
     - exceptiongroup
   commands:
     - pip check
+    - pytest -v tests
   requires:
     - pip
+    - pytest
 
 about:
-  home: https://pypi.org/project/exceptiongroup/
+  home: https://pypi.org/project/exceptiongroup
   summary: Backport of PEP 654 (exception groups)
   description: |
     "This is a backport of the BaseExceptionGroup and ExceptionGroup classes from Python 3.11.


### PR DESCRIPTION
exceptiongroup 1.3.0 

**Destination channel:** Defaults

### Links

- [PKG-10243]
- dev_url:        https://github.com/agronholm/exceptiongroup/tree/1.3.0
- conda_forge:    https://github.com/conda-forge/exceptiongroup-feedstock
- pypi:           https://pypi.org/project/exceptiongroup/1.3.0
- pypi inspector: https://inspector.pypi.io/project/exceptiongroup/1.3.0

### Explanation of changes:

- new version number


[PKG-10243]: https://anaconda.atlassian.net/browse/PKG-10243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ